### PR TITLE
Decrease minimum sdk requirements to API 8

### DIFF
--- a/paperdb/build.gradle
+++ b/paperdb/build.gradle
@@ -5,7 +5,7 @@ android {
     buildToolsVersion "21.1.2"
 
     defaultConfig {
-        minSdkVersion 15
+        minSdkVersion 8
         targetSdkVersion 21
         versionCode 1
         versionName "1.0"


### PR DESCRIPTION
This removes the useless app which did not contain any samples and decreases the minimum sdk from 15 to 8.

I have choosen 8 because the test dependency of Hawk depends on API 8 and with API 8 we are targeting 99% of the android audience anyways, so it seems to be a reasonable number to me.