### PR TITLE
Removed Context from DbStoragePlainFile

### DIFF
--- a/paperdb/src/main/java/io/paperdb/Book.java
+++ b/paperdb/src/main/java/io/paperdb/Book.java
@@ -7,7 +7,7 @@ public class Book {
     private final Storage mStorage;
 
     protected Book(Context context, String dbName) {
-        mStorage = new DbStoragePlainFile(context.getApplicationContext(), dbName);
+        mStorage = new DbStoragePlainFile(context.getApplicationContext().getFilesDir(), dbName);
     }
 
     /**

--- a/paperdb/src/main/java/io/paperdb/DbStoragePlainFile.java
+++ b/paperdb/src/main/java/io/paperdb/DbStoragePlainFile.java
@@ -1,6 +1,5 @@
 package io.paperdb;
 
-import android.content.Context;
 import android.util.Log;
 
 import com.esotericsoftware.kryo.Kryo;
@@ -27,7 +26,6 @@ import static io.paperdb.Paper.TAG;
 
 public class DbStoragePlainFile implements Storage {
 
-    private final Context mContext;
     private final String mDbName;
     private String mFilesDir;
     private boolean mPaperDirIsCreated;
@@ -66,8 +64,8 @@ public class DbStoragePlainFile implements Storage {
         return kryo;
     }
 
-    public DbStoragePlainFile(Context context, String dbName) {
-        mContext = context;
+    public DbStoragePlainFile(File filesDir, String dbName) {
+        mFilesDir = getDbPath(filesDir, dbName);
         mDbName = dbName;
     }
 
@@ -75,9 +73,8 @@ public class DbStoragePlainFile implements Storage {
     public synchronized void destroy() {
         assertInit();
 
-        final String dbPath = getDbPath(mContext, mDbName);
-        if (!deleteDirectory(dbPath)) {
-            Log.e(TAG, "Couldn't delete Paper dir " + dbPath);
+        if (!deleteDirectory(mFilesDir)) {
+            Log.e(TAG, "Couldn't delete Paper dir " + mFilesDir);
         }
         mPaperDirIsCreated = false;
     }
@@ -216,8 +213,8 @@ public class DbStoragePlainFile implements Storage {
         }
     }
 
-    private String getDbPath(Context context, String dbName) {
-        return context.getFilesDir() + File.separator + dbName;
+    private String getDbPath(File filesDir, String dbName) {
+        return filesDir + File.separator + dbName;
     }
 
     private void assertInit() {
@@ -228,7 +225,6 @@ public class DbStoragePlainFile implements Storage {
     }
 
     private void createPaperDir() {
-        mFilesDir = getDbPath(mContext, mDbName);
         if (!new File(mFilesDir).exists()) {
             boolean isReady = new File(mFilesDir).mkdirs();
             if (!isReady) {


### PR DESCRIPTION
Removed Context from DbStoragePlainFile to decrease coupling storage with android classes. Storage needed only path to directory with db files.