### PR TITLE
Fixes #40: Allow logging kryo marshalling

### DIFF
--- a/paperdb/src/main/java/io/paperdb/Book.java
+++ b/paperdb/src/main/java/io/paperdb/Book.java
@@ -96,4 +96,8 @@ public class Book {
         return mStorage.getAllKeys();
     }
 
+    public void setLogLevel(int level) {
+        mStorage.setLogLevel(level);
+    }
+
 }

--- a/paperdb/src/main/java/io/paperdb/DbStoragePlainFile.java
+++ b/paperdb/src/main/java/io/paperdb/DbStoragePlainFile.java
@@ -188,6 +188,11 @@ public class DbStoragePlainFile implements Storage {
         }
     }
 
+    @Override
+    public void setLogLevel(int level) {
+        com.esotericsoftware.minlog.Log.set(level);
+    }
+
     private File getOriginalFile(String key) {
         final String tablePath = mFilesDir + File.separator + key + ".pt";
         return new File(tablePath);

--- a/paperdb/src/main/java/io/paperdb/Paper.java
+++ b/paperdb/src/main/java/io/paperdb/Paper.java
@@ -6,6 +6,7 @@ import android.os.Bundle;
 
 import com.esotericsoftware.kryo.Serializer;
 
+import java.util.Map;
 import java.util.HashMap;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -120,7 +121,13 @@ public class Paper {
         init(context);
         book().destroy();
     }
-    
+
+    public static void setLogLevel(int level) {
+        for (Map.Entry<String, Book> entry : mBookMap.entrySet()) {
+            entry.getValue().setLogLevel(level);
+        }
+    }
+
     /**
      * Adds a custom serializer for a specific class
      * When used, must be called right after Paper.init()

--- a/paperdb/src/main/java/io/paperdb/Storage.java
+++ b/paperdb/src/main/java/io/paperdb/Storage.java
@@ -15,4 +15,6 @@ interface Storage {
     void deleteIfExists(String key);
 
     List<String> getAllKeys();
+
+    void setLogLevel(int level);
 }


### PR DESCRIPTION
Add an api to allow logging object marshaling.
Uses the levels defined at
https://github.com/EsotericSoftware/minlog/blob/master/src/com/esotericsoftware/minlog/Log.java#L10

It may make sense to copy the log level constants into the paper namespace so it's easier for integrators to know the different levels. 
