### PR TITLE
add lastModified for given key to return timestamp of last update

### DIFF
--- a/app/src/main/java/paperdb/io/paperdb/MainActivity.java
+++ b/app/src/main/java/paperdb/io/paperdb/MainActivity.java
@@ -2,6 +2,7 @@ package paperdb.io.paperdb;
 
 import android.os.Bundle;
 import android.support.v7.app.AppCompatActivity;
+import android.util.Log;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
@@ -16,6 +17,7 @@ import static java.util.Arrays.asList;
 
 public class MainActivity extends AppCompatActivity {
 
+    private static final String TAG = MainActivity.class.getSimpleName();
     public static final String PERSON = "person";
 
     @Override
@@ -42,6 +44,9 @@ public class MainActivity extends AppCompatActivity {
             public void onClick(View v) {
                 LongHolder o1 = Paper.book().read("o1", new LongHolder(-1L));
                 LongListHolder o2 = Paper.book().read("o2", new LongListHolder(asList(-1L)));
+
+                long lastModified = Paper.book().lastModified("o1");
+                Log.d(TAG, "lastModified: " + lastModified);
 
                 btnRead.setText("Read: " + o1.getValue() + " : " + o2.getValue().get(0));
             }

--- a/paperdb/src/androidTest/java/io/paperdb/PaperTest.java
+++ b/paperdb/src/androidTest/java/io/paperdb/PaperTest.java
@@ -18,6 +18,7 @@ import static junit.framework.Assert.assertEquals;
 import static junit.framework.TestCase.assertTrue;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
 
 @RunWith(AndroidJUnit4.class)
 public class PaperTest {
@@ -179,5 +180,26 @@ public class PaperTest {
         DateTime now = DateTime.now(DateTimeZone.UTC);
         Paper.book("custom").write("joda-datetime", now);
         assertEquals(Paper.book("custom").read("joda-datetime"), now);
+    }
+
+    @Test
+    public void testTimestampNoObject() {
+        Paper.book().destroy();
+        long timestamp = Paper.book().lastModified("city");
+        assertEquals(-1, timestamp);
+    }
+
+    @Test
+    public void testTimestamp() {
+        long testStartMS = System.currentTimeMillis();
+
+        Paper.book().destroy();
+        Paper.book().write("city", "Lund");
+
+        long fileWriteMS = Paper.book().lastModified("city");
+        assertNotEquals(-1, fileWriteMS);
+
+        long elapsed = fileWriteMS - testStartMS;
+        assertThat(elapsed >= 0).isTrue();
     }
 }

--- a/paperdb/src/main/java/io/paperdb/Book.java
+++ b/paperdb/src/main/java/io/paperdb/Book.java
@@ -79,6 +79,16 @@ public class Book {
     }
 
     /**
+     * Return lastModified timestamp of last write
+     *
+     * @param key object key
+     * @return timestamp of last write for given key if it exists, otherwise -1
+     */
+    public long lastModified(String key){
+        return exist(key) ? mStorage.lastModified(key) : -1;
+    }
+
+    /**
      * Delete saved object for given key if it is exist.
      *
      * @param key object key

--- a/paperdb/src/main/java/io/paperdb/Book.java
+++ b/paperdb/src/main/java/io/paperdb/Book.java
@@ -79,10 +79,10 @@ public class Book {
     }
 
     /**
-     * Return lastModified timestamp of last write
+     * Returns lastModified timestamp of last write
      *
      * @param key object key
-     * @returns timestamp of last write for given key if it exists, otherwise -1
+     * @return timestamp of last write for given key if it exists, otherwise -1
      */
     public long lastModified(String key){
         return mStorage.lastModified(key);

--- a/paperdb/src/main/java/io/paperdb/Book.java
+++ b/paperdb/src/main/java/io/paperdb/Book.java
@@ -82,10 +82,10 @@ public class Book {
      * Return lastModified timestamp of last write
      *
      * @param key object key
-     * @return timestamp of last write for given key if it exists, otherwise -1
+     * @returns timestamp of last write for given key if it exists, otherwise -1
      */
     public long lastModified(String key){
-        return exist(key) ? mStorage.lastModified(key) : -1;
+        return mStorage.lastModified(key);
     }
 
     /**

--- a/paperdb/src/main/java/io/paperdb/DbStoragePlainFile.java
+++ b/paperdb/src/main/java/io/paperdb/DbStoragePlainFile.java
@@ -158,8 +158,9 @@ public class DbStoragePlainFile implements Storage {
     @Override
     public synchronized long lastModified(String key) {
         assertInit();
+
         final File originalFile = getOriginalFile(key);
-        return originalFile.lastModified();
+        return originalFile.exists() ? originalFile.lastModified() : -1;
     }
 
     @Override

--- a/paperdb/src/main/java/io/paperdb/DbStoragePlainFile.java
+++ b/paperdb/src/main/java/io/paperdb/DbStoragePlainFile.java
@@ -156,6 +156,13 @@ public class DbStoragePlainFile implements Storage {
     }
 
     @Override
+    public synchronized long lastModified(String key) {
+        assertInit();
+        final File originalFile = getOriginalFile(key);
+        return originalFile.lastModified();
+    }
+
+    @Override
     public List<String> getAllKeys() {
         assertInit();
 

--- a/paperdb/src/main/java/io/paperdb/Storage.java
+++ b/paperdb/src/main/java/io/paperdb/Storage.java
@@ -12,6 +12,8 @@ interface Storage {
 
     boolean exist(String key);
 
+    long lastModified(String key);
+
     void deleteIfExists(String key);
 
     List<String> getAllKeys();


### PR DESCRIPTION
Small addition so implementations can check when an object was last updated. This simplifies scenarios where Paper is used as an 'offline-first' cache mechanism allowing implementations to decide if a cached object is stale and requires a network call and update.