### PR TITLE
Fix crashes on multi thread calls to read/write/destroy 

### DIFF
--- a/app/src/main/java/paperdb/io/paperdb/MainActivity.java
+++ b/app/src/main/java/paperdb/io/paperdb/MainActivity.java
@@ -62,18 +62,18 @@ public class MainActivity extends AppCompatActivity {
     }
 
     private void testReadWriteAsync() {
-        final int iterations = 10;
-        readWriteKey("key1", iterations);
-        readWriteKey("key2", iterations);
+        final int iterations = 1000;
+        writeReadDestroy("key1", iterations);
+        writeReadDestroy("key2", iterations);
     }
 
-    private void readWriteKey(final String key, final int iterations) {
+    private void writeReadDestroy(final String key, final int iterations) {
         new Thread() {
             @Override
             public void run() {
                 for (int i = 0; i < iterations; i++) {
                     Paper.book().write(key, "key:" + key + " iteration#" + i);
-                    Log.d("PAPER_APP", "" + Paper.book().<String>read(key));
+                    Log.d("PAPER_APP", "read key:" + key + "=" + Paper.book().<String>read(key));
                     // This caused the issue on multi-thread paper db dir creation
                     Paper.book().destroy();
                 }

--- a/app/src/main/java/paperdb/io/paperdb/MainActivity.java
+++ b/app/src/main/java/paperdb/io/paperdb/MainActivity.java
@@ -1,5 +1,7 @@
 package paperdb.io.paperdb;
 
+import android.annotation.SuppressLint;
+import android.os.AsyncTask;
 import android.os.Bundle;
 import androidx.appcompat.app.AppCompatActivity;
 import android.util.Log;
@@ -8,17 +10,15 @@ import android.view.MenuItem;
 import android.view.View;
 import android.widget.Button;
 
+import java.lang.ref.WeakReference;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import io.paperdb.Paper;
 
-import static java.util.Arrays.asList;
-
 
 public class MainActivity extends AppCompatActivity {
-
-    private static final String TAG = MainActivity.class.getSimpleName();
-    public static final String PERSON = "person";
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -30,25 +30,17 @@ public class MainActivity extends AppCompatActivity {
         findViewById(R.id.test_write).setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
-                LongHolder o1 = new LongHolder(12L);
-                LongListHolder o2 = new LongListHolder(asList(23L));
-                Paper.book().write("o1", o1);
-                Paper.book().write("o2", o2);
+                new SimpleWrite().execute();
             }
         });
 
         final Button btnRead = findViewById(R.id.test_read);
 
         btnRead.setOnClickListener(new View.OnClickListener() {
+            @SuppressLint("SetTextI18n")
             @Override
             public void onClick(View v) {
-                LongHolder o1 = Paper.book().read("o1", new LongHolder(-1L));
-                LongListHolder o2 = Paper.book().read("o2", new LongListHolder(asList(-1L)));
-
-                //long lastModified = Paper.book().lastModified("o1");
-                //Log.d(TAG, "lastModified: " + lastModified);
-
-                btnRead.setText("Read: " + o1.getValue() + " : " + o2.getValue().get(0));
+                new SimpleRead(btnRead).execute();
             }
         });
 
@@ -67,13 +59,15 @@ public class MainActivity extends AppCompatActivity {
         writeReadDestroy("key2", iterations);
     }
 
+    @SuppressWarnings("SameParameterValue")
     private void writeReadDestroy(final String key, final int iterations) {
         new Thread() {
             @Override
             public void run() {
                 for (int i = 0; i < iterations; i++) {
                     Paper.book().write(key, "key:" + key + " iteration#" + i);
-                    Log.d("PAPER_APP", "read key:" + key + "=" + Paper.book().<String>read(key));
+                    Log.d(Thread.currentThread().getName(), "All keys:" + Paper.book().getAllKeys().toString());
+                    Log.d(Thread.currentThread().getName(), "read key:" + key + "=" + Paper.book().<String>read(key));
                     // This caused the issue on multi-thread paper db dir creation
                     Paper.book().destroy();
                 }
@@ -145,4 +139,47 @@ public class MainActivity extends AppCompatActivity {
             super(value);
         }
     }
+
+    // So fun to write async tasks in java in 2020. How did we live with that?
+    private static class SimpleRead extends AsyncTask<Void, Void, ArrayList<AbstractValueHolder>> {
+        private final WeakReference<Button> wrBtnRead;
+
+        private SimpleRead(Button btnRead) {
+            wrBtnRead = new WeakReference<>(btnRead);
+        }
+
+        @Override
+        protected ArrayList<AbstractValueHolder> doInBackground(Void... voids) {
+            LongHolder o1 = Paper.book().read("o1", new LongHolder(-1L));
+            LongListHolder o2 = Paper.book().read("o2",
+                    new LongListHolder(Collections.singletonList(-1L)));
+            ArrayList<AbstractValueHolder> result = new ArrayList<>();
+            result.add(o1);
+            result.add(o2);
+            return result;
+        }
+
+        @SuppressLint("SetTextI18n")
+        @Override
+        protected void onPostExecute(ArrayList<AbstractValueHolder> result) {
+            Button btnRead = wrBtnRead.get();
+            LongHolder o1 = (LongHolder) result.get(0);
+            LongListHolder o2 = (LongListHolder) result.get(1);
+            if (btnRead != null) {
+                btnRead.setText("Read: " + o1.getValue() + " : " + o2.getValue().get(0));
+            }
+        }
+    }
+
+    private static class SimpleWrite extends AsyncTask<Void, Void, Void> {
+        @Override
+        protected Void doInBackground(Void... voids) {
+            LongHolder o1 = new LongHolder(12L);
+            LongListHolder o2 = new LongListHolder(Collections.singletonList(23L));
+            Paper.book().write("o1", o1);
+            Paper.book().write("o2", o2);
+            return null;
+        }
+    }
+
 }

--- a/app/src/main/java/paperdb/io/paperdb/MainActivity.java
+++ b/app/src/main/java/paperdb/io/paperdb/MainActivity.java
@@ -2,6 +2,7 @@ package paperdb.io.paperdb;
 
 import android.os.Bundle;
 import androidx.appcompat.app.AppCompatActivity;
+import android.util.Log;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
@@ -36,7 +37,7 @@ public class MainActivity extends AppCompatActivity {
             }
         });
 
-        final Button btnRead = (Button) findViewById(R.id.test_read);
+        final Button btnRead = findViewById(R.id.test_read);
 
         btnRead.setOnClickListener(new View.OnClickListener() {
             @Override
@@ -50,6 +51,34 @@ public class MainActivity extends AppCompatActivity {
                 btnRead.setText("Read: " + o1.getValue() + " : " + o2.getValue().get(0));
             }
         });
+
+        final Button btnReadWriteAsync = findViewById(R.id.test_read_write_async);
+        btnReadWriteAsync.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View view) {
+                testReadWriteAsync();
+            }
+        });
+    }
+
+    private void testReadWriteAsync() {
+        final int iterations = 10;
+        readWriteKey("key1", iterations);
+        readWriteKey("key2", iterations);
+    }
+
+    private void readWriteKey(final String key, final int iterations) {
+        new Thread() {
+            @Override
+            public void run() {
+                for (int i = 0; i < iterations; i++) {
+                    Paper.book().write(key, "key:" + key + " iteration#" + i);
+                    Log.d("PAPER_APP", "" + Paper.book().<String>read(key));
+                    // This caused the issue on multi-thread paper db dir creation
+                    Paper.book().destroy();
+                }
+            }
+        }.start();
     }
 
     @Override

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -4,11 +4,18 @@
    android:layout_height="match_parent"
    android:gravity="center_horizontal"
    android:orientation="vertical"
-   android:paddingBottom="@dimen/activity_vertical_margin"
    android:paddingLeft="@dimen/activity_horizontal_margin"
-   android:paddingRight="@dimen/activity_horizontal_margin"
    android:paddingTop="@dimen/activity_vertical_margin"
-   tools:context=".MainActivity">
+   android:paddingRight="@dimen/activity_horizontal_margin"
+   android:paddingBottom="@dimen/activity_vertical_margin"
+   tools:context=".MainActivity"
+   tools:ignore="HardcodedText">
+
+   <TextView
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      android:text="This is an simple utility app. Do not use it as reference Paper client implementation."
+      android:textSize="24sp" />
 
    <Button
       android:id="@+id/test_write"

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -1,28 +1,34 @@
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
-                xmlns:tools="http://schemas.android.com/tools"
-                android:layout_width="match_parent"
-                android:layout_height="match_parent"
-                android:paddingBottom="@dimen/activity_vertical_margin"
-                android:paddingLeft="@dimen/activity_horizontal_margin"
-                android:paddingRight="@dimen/activity_horizontal_margin"
-                android:paddingTop="@dimen/activity_vertical_margin"
-                tools:context=".MainActivity">
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+   xmlns:tools="http://schemas.android.com/tools"
+   android:layout_width="match_parent"
+   android:layout_height="match_parent"
+   android:gravity="center_horizontal"
+   android:orientation="vertical"
+   android:paddingBottom="@dimen/activity_vertical_margin"
+   android:paddingLeft="@dimen/activity_horizontal_margin"
+   android:paddingRight="@dimen/activity_horizontal_margin"
+   android:paddingTop="@dimen/activity_vertical_margin"
+   tools:context=".MainActivity">
 
    <Button
       android:id="@+id/test_write"
       android:layout_width="wrap_content"
       android:layout_height="wrap_content"
-      android:layout_centerHorizontal="true"
       android:layout_marginTop="32dp"
-      android:text="Write"/>
+      android:text="Write" />
 
    <Button
       android:id="@+id/test_read"
       android:layout_width="wrap_content"
       android:layout_height="wrap_content"
-      android:layout_below="@id/test_write"
-      android:layout_centerHorizontal="true"
       android:layout_marginTop="16dp"
-      android:text="Read"/>
+      android:text="Read" />
 
-</RelativeLayout>
+   <Button
+      android:id="@+id/test_read_write_async"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:layout_marginTop="16dp"
+      android:text="Read/Write async" />
+
+</LinearLayout>

--- a/paperdb/src/androidTest/java/io/paperdb/multithread/MultiThreadTest.java
+++ b/paperdb/src/androidTest/java/io/paperdb/multithread/MultiThreadTest.java
@@ -127,9 +127,10 @@ public class MultiThreadTest {
         ExecutorService executor = Executors.newFixedThreadPool(2);
         List<Callable<Object>> tasks = new LinkedList<>();
 
-        tasks.add(Executors.callable(readWriteDestroy("multi_thread_key_1", 100)));
-        tasks.add(Executors.callable(readWriteDestroy("multi_thread_key_2", 100)));
+        tasks.add(Executors.callable(writeReadDestroy("multi_thread_key_1", 200)));
+        tasks.add(Executors.callable(writeReadDestroy("multi_thread_key_2", 200)));
 
+        // Make sure no crash produced
         List<Future<Object>> futures = executor.invokeAll(tasks);
         for (Future<Object> future : futures) {
             future.get();
@@ -179,12 +180,14 @@ public class MultiThreadTest {
         };
     }
 
-    private Runnable readWriteDestroy(final String key, final int iterations) {
+    private Runnable writeReadDestroy(final String key, final int iterations) {
         return new Runnable() {
             @Override
             public void run() {
                 for (int i = 0; i < iterations; i++) {
+                    Paper.book().getAllKeys();
                     Paper.book().write(key, "key:" + key + " iteration#" + i);
+                    Paper.book().read(key);
                     Paper.book().destroy();
                 }
             }

--- a/paperdb/src/androidTest/java/io/paperdb/multithread/MultiThreadTest.java
+++ b/paperdb/src/androidTest/java/io/paperdb/multithread/MultiThreadTest.java
@@ -115,6 +115,27 @@ public class MultiThreadTest {
         }
     }
 
+    /**
+     * Reproduces the issues
+     * https://github.com/pilgr/Paper/issues/66
+     * https://github.com/pilgr/Paper/issues/108
+     * https://github.com/pilgr/Paper/issues/114
+     * https://github.com/pilgr/Paper/issues/159
+     */
+    @Test
+    public void testWriteReadDestroyMultiThread() throws Exception {
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+        List<Callable<Object>> tasks = new LinkedList<>();
+
+        tasks.add(Executors.callable(readWriteDestroy("multi_thread_key_1", 100)));
+        tasks.add(Executors.callable(readWriteDestroy("multi_thread_key_2", 100)));
+
+        List<Future<Object>> futures = executor.invokeAll(tasks);
+        for (Future<Object> future : futures) {
+            future.get();
+        }
+    }
+
     @NonNull
     private CountDownLatch startWritingLargeDataSetInSeparateThread(
             @SuppressWarnings("SameParameterValue") final String key) throws InterruptedException {
@@ -154,6 +175,18 @@ public class MultiThreadTest {
             @Override
             public void run() {
                 Paper.book().read("persons");
+            }
+        };
+    }
+
+    private Runnable readWriteDestroy(final String key, final int iterations) {
+        return new Runnable() {
+            @Override
+            public void run() {
+                for (int i = 0; i < iterations; i++) {
+                    Paper.book().write(key, "key:" + key + " iteration#" + i);
+                    Paper.book().destroy();
+                }
             }
         };
     }

--- a/paperdb/src/main/java/io/paperdb/DbStoragePlainFile.java
+++ b/paperdb/src/main/java/io/paperdb/DbStoragePlainFile.java
@@ -103,7 +103,6 @@ class DbStoragePlainFile {
         // and block future per-key operations until destroy is completed
         try {
             keyLocker.acquireGlobal();
-            assertInit();
 
             if (!deleteDirectory(mDbPath)) {
                 Log.e(TAG, "Couldn't delete Paper dir " + mDbPath);

--- a/paperdb/src/main/java/io/paperdb/KeyLocker.java
+++ b/paperdb/src/main/java/io/paperdb/KeyLocker.java
@@ -16,10 +16,8 @@ class KeyLocker {
     private Semaphore global = new Semaphore(1, true);
 
     void acquire(String key) {
-        int availablePermits = global.availablePermits();
-
         // If global semaphore is acquired, wait until global operation is done
-        if (availablePermits == 0) {
+        if (global.availablePermits() == 0) {
             global.acquireUninterruptibly();
             global.release();
         }


### PR DESCRIPTION
Multi thread access to `assertInit` was causing race conditions on creating Paper dir which caused exception like `RuntimeException("Couldn't create Paper dir:..)`. That was easy fixed with adding `synchronized` to the function.

The other problem raised after that: what happened if `destroy` is called while `read/write` still in progress? That caused many issues on reading/writing to file. Since `destroy` makes changes for all keys, and `read/write` synchronized by particular key, I've introduced a new global Semaphore to lock all per-key operations while global operation is in progress. Also global operations (like `destroy` and `getAllKeys`) won't be started before currently running per-key operations (`read`, `write` etc) are completed.

Fix https://github.com/pilgr/Paper/issues/66
Fix https://github.com/pilgr/Paper/issues/108
Fix https://github.com/pilgr/Paper/issues/114
Fix https://github.com/pilgr/Paper/issues/159
Fix https://github.com/pilgr/Paper/issues/160
