### PR TITLE
Explicitly Make PaperTable Public

### DIFF
--- a/paperdb/src/main/java/io/paperdb/PaperTable.java
+++ b/paperdb/src/main/java/io/paperdb/PaperTable.java
@@ -1,6 +1,6 @@
 package io.paperdb;
 
-class PaperTable<T> {
+public class PaperTable<T> {
 
     @SuppressWarnings("UnusedDeclaration") PaperTable() {
     }


### PR DESCRIPTION
This PR makes PaperTable explicitly public. This is to avoid R8 obsfuscation removing the public access modifier that started happening in AGP 7.0.2

Steps to reproduce (Taken from #188 )

- Checkout master branch
- extract and apply attached patch (use agp 7.0.2, target sdk 30 and moved models in own package) [AGP_702_breaks_Book_read()_after_write.patch.zip](https://github.com/pilgr/Paper/files/7120825/AGP_702_breaks_Book_read._after_write.patch.zip)
- Run Paper sample app
- Click on "write"
- click on "read"
- -> App will crash with following stacktrace

```
2021-09-07 12:25:56.147 7132-7177/paperdb.io.paperdb W/erdb.io.paperd: Accessing hidden method Lsun/nio/ch/DirectBuffer;->cleaner()Lsun/misc/Cleaner; (greylist, linking, allowed)
2021-09-07 12:25:56.147 7132-7177/paperdb.io.paperdb W/erdb.io.paperd: Accessing hidden method Lsun/misc/Cleaner;->clean()V (greylist,core-platform-api, linking, allowed)
2021-09-07 12:25:56.154 7132-7177/paperdb.io.paperdb W/erdb.io.paperd: Accessing hidden field Ljava/util/Arrays$ArrayList;->a:[Ljava/lang/Object; (greylist, reflection, allowed)
2021-09-07 12:25:56.154 7132-7177/paperdb.io.paperdb W/erdb.io.paperd: Accessing hidden field Ljava/util/Collections$UnmodifiableCollection;->c:Ljava/util/Collection; (greylist, reflection, allowed)
2021-09-07 12:25:56.154 7132-7177/paperdb.io.paperdb W/erdb.io.paperd: Accessing hidden field Ljava/util/Collections$UnmodifiableMap;->m:Ljava/util/Map; (greylist, reflection, allowed)
2021-09-07 12:25:56.157 7132-7177/paperdb.io.paperdb W/erdb.io.paperd: Accessing hidden field Ljava/util/Collections$SynchronizedCollection;->c:Ljava/util/Collection; (greylist, reflection, allowed)
2021-09-07 12:25:56.157 7132-7177/paperdb.io.paperdb W/erdb.io.paperd: Accessing hidden field Ljava/util/Collections$SynchronizedMap;->m:Ljava/util/Map; (greylist, reflection, allowed)
2021-09-07 12:25:56.163 7132-7177/paperdb.io.paperdb E/AndroidRuntime: FATAL EXCEPTION: AsyncTask #1
    Process: paperdb.io.paperdb, PID: 7132
    java.lang.RuntimeException: An error occurred while executing doInBackground()
        at android.os.AsyncTask$4.done(AsyncTask.java:415)
        at java.util.concurrent.FutureTask.finishCompletion(FutureTask.java:383)
        at java.util.concurrent.FutureTask.setException(FutureTask.java:252)
        at java.util.concurrent.FutureTask.run(FutureTask.java:271)
        at android.os.AsyncTask$SerialExecutor$1.run(AsyncTask.java:305)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1167)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:641)
        at java.lang.Thread.run(Thread.java:923)
     Caused by: io.paperdb.PaperDbException: Couldn't read/deserialize file /data/user/0/paperdb.io.paperdb/files/io.paperdb/o1.pt for table o1
        at io.paperdb.DbStoragePlainFile.readTableFile(:323)
        at io.paperdb.DbStoragePlainFile.select(:166)
        at io.paperdb.Book.read(:73)
        at paperdb.io.paperdb.MainActivity$e.a(:131)
        at paperdb.io.paperdb.MainActivity$e.doInBackground(:120)
        at android.os.AsyncTask$3.call(AsyncTask.java:394)
        at java.util.concurrent.FutureTask.run(FutureTask.java:266)
        at android.os.AsyncTask$SerialExecutor$1.run(AsyncTask.java:305) 
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1167) 
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:641) 
        at java.lang.Thread.run(Thread.java:923) 
     Caused by: com.esotericsoftware.kryo.KryoException: Error constructing instance of class: io.paperdb.PaperTable
        at com.esotericsoftware.kryo.Kryo$DefaultInstantiatorStrategy$2.newInstance(:1300)
        at com.esotericsoftware.kryo.Kryo.newInstance(:1139)
        at com.esotericsoftware.kryo.serializers.FieldSerializer.create(:562)
        at com.esotericsoftware.kryo.serializers.FieldSerializer.read(:538)
        at com.esotericsoftware.kryo.Kryo.readObject(:712)
        at io.paperdb.DbStoragePlainFile.readContent(:332)
        at io.paperdb.DbStoragePlainFile.readTableFile(:316)
        at io.paperdb.DbStoragePlainFile.select(:166) 
        at io.paperdb.Book.read(:73) 
        at paperdb.io.paperdb.MainActivity$e.a(:131) 
        at paperdb.io.paperdb.MainActivity$e.doInBackground(:120) 
        at android.os.AsyncTask$3.call(AsyncTask.java:394) 
        at java.util.concurrent.FutureTask.run(FutureTask.java:266) 
        at android.os.AsyncTask$SerialExecutor$1.run(AsyncTask.java:305) 
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1167) 
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:641) 
        at java.lang.Thread.run(Thread.java:923) 
     Caused by: java.lang.IllegalAccessException: java.lang.Class<io.paperdb.PaperTable> is not accessible from java.lang.Class<com.esotericsoftware.kryo.Kryo$DefaultInstantiatorStrategy$2>
        at java.lang.reflect.Constructor.newInstance0(Native Method)
        at java.lang.reflect.Constructor.newInstance(Constructor.java:343)
        at com.esotericsoftware.kryo.Kryo$DefaultInstantiatorStrategy$2.newInstance(:1298)
        at com.esotericsoftware.kryo.Kryo.newInstance(:1139) 
        at com.esotericsoftware.kryo.serializers.FieldSerializer.create(:562) 
        at com.esotericsoftware.kryo.serializers.FieldSerializer.read(:538) 
        at com.esotericsoftware.kryo.Kryo.readObject(:712) 
        at io.paperdb.DbStoragePlainFile.readContent(:332) 
        at io.paperdb.DbStoragePlainFile.readTableFile(:316) 
        at io.paperdb.DbStoragePlainFile.select(:166) 
        at io.paperdb.Book.read(:73) 
        at paperdb.io.paperdb.MainActivity$e.a(:131) 
        at paperdb.io.paperdb.MainActivity$e.doInBackground(:120) 
        at android.os.AsyncTask$3.call(AsyncTask.java:394) 
        at java.util.concurrent.FutureTask.run(FutureTask.java:266) 
        at android.os.AsyncTask$SerialExecutor$1.run(AsyncTask.java:305) 
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1167) 
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:641) 
        at java.lang.Thread.run(Thread.java:923) 
```

Testing My Build
- Checkout from my commit
- Un Comment line 26 in build.gradle in Paper.app to implement the local library.
- Comment out line 27 
- Run Paper sample app
- Click on "write"
- click on "read"
- App will not crash anymore


