### PR TITLE
Update README to mention additional proguard rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,15 @@ also you can implement _Serializable_ for all your data classes and keep all of 
 ```
 -keep class * implements java.io.Serializable { *; }
 ```
+* If your data models use enums, you should also keep them:
 
+```
+-keep enum your.app.data.model.** { *; }
+```
+* And if you rely on Kotlin's `emptyList()`/`emptyMap()`/`emptySet` to assign values to your data models, it is relevant to keep `EmptyList`/`EmptyMap`/`EmptySet` as well:
+```
+-keep class kotlin.collections.* { *; }
+```
 ### How it works
 Paper is based on the following assumptions:
 - Datasets on mobile devices are small and usually don't have relations in between; 


### PR DESCRIPTION
Trying to save everyone's time when facing deserialization errors due to code obfuscation.

Notes:
- The rule for `EmptyList`/`EmptyMap`/`EmptySet` can probably be more specific instead of package-wide in `kotlin.collections.*`. 
- It would be important to mention somewhere in the README that changing a enum's constant name will break deserialization. Do you agree with this statement? This is not something I've faced myself but it was my understanding after digging deeper in the default kryo behavior when deserializing enums :)